### PR TITLE
fix-remote: Correctly check for remotes when not in git repo.

### DIFF
--- a/bin/git-hub-clone
+++ b/bin/git-hub-clone
@@ -10,8 +10,7 @@ _fork(){
 
 	github /repos/$FULL_REPO/forks >| .tmp_forks
 
-	if [ ! $(cat .tmp_forks | json -a owner.login | grep DavidSouther) ; then
-	else
+	if [ ! $(cat .tmp_forks | json -a owner.login | fgrep "$(github_user)") ] ; then
 		github /repos/$FULL_REPO/forks .tmp_fork
 		# Sleep for a moment, to let github register the fork.
 		sleep 1
@@ -28,7 +27,7 @@ clone(){
 
 	_fork $FULL_REPO $REPO $USER
 
-	git clone git@github.com:$USER/$REPO.git 2>&1 >/dev/null
+	git clone $Q git@github.com:$USER/$REPO.git 2>&1 >/dev/null
 	cd $REPO
 	git remote add upstream git@github.com:$FULL_REPO.git
 
@@ -49,7 +48,7 @@ help(){
 	echo "	<org/repo>: The organization and repository name to clone from."
 }
 
-if [ "x$1" == "-h"] ; then
+if [ "x$1" == "-h" ] ; then
 	help
 else
 	clone $@

--- a/bin/git-hub-feature
+++ b/bin/git-hub-feature
@@ -4,6 +4,7 @@ source git-hub-helpers
 
 # Begin working on a new feature
 start(){
+	BRANCH=${1:?"Please specify a branch name."}
 	git stash
 	# Just a semantic `git checkout -b $BRANCH $MASTER`
 	git checkout -b $BRANCH $MASTER

--- a/bin/git-hub-helpers
+++ b/bin/git-hub-helpers
@@ -79,9 +79,9 @@ find_repo(){
 }
 
 # Get the info about the repos.
-GH_ORIGIN=$(git remote -v 2>/dev/null | grep $ORIGIN | head -1 | find_repo)
+GH_ORIGIN=$(git remote -v 2>/dev/null | fgrep "$ORIGIN" | head -1 | find_repo)
 GH_ORIGIN_USER=$(echo $GH_ORIGIN | awk -F/ '{print $1}')
-GH_UPSTREAM=$(git remote -v 2>/dev/null | grep $UPSTREAM | head -1 | find_repo)
+GH_UPSTREAM=$(git remote -v 2>/dev/null | fgrep "$UPSTREAM" | head -1 | find_repo)
 GH_UPSTREAM_USER=$(echo $GH_UPSTREAM | awk -F/ '{print $1}')
 
 # Always starting on some branch.


### PR DESCRIPTION
4e2eab7 - Correctly check for remotes when not in git repo. <David Souther>
